### PR TITLE
rootProject名変更

### DIFF
--- a/consumer/settings.gradle
+++ b/consumer/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'lineworks_bot_sample'
+rootProject.name = 'consumer'

--- a/publisher/settings.gradle
+++ b/publisher/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'lineworks_bot_sample'
+rootProject.name = 'publisher'


### PR DESCRIPTION
## 変更箇所
[publisher/settings.gradle](https://github.com/solxyz-jsn/lineworks-sample-mq/pull/1/files#diff-a4447f068b5bb797c4c0ef3811c3a3f20c80878b95b50daa811fe9c375d222db)

[consumer/settings.gradle](https://github.com/solxyz-jsn/lineworks-sample-mq/pull/1/files#diff-af4840823baafe8de0008bab7a1d1303371a62c2a9433ca132ccff3ad8bd3fd5)

 rootProject名をそれぞれ、`publisher`と`consumer`に変更

## 変更理由

アカデミー用記事には「プロジェクト名が`publisher`、`consumer`として表示される」と記載しているが、サンプルコード動作確認時のVisual Studio Code（バージョン1.85）ではrootProject.nameに設定している値がプロジェクト名として表示されることを確認したため（スクリーンショット参照）

## スクリーンショット

Visual Studio Code（バージョン1.85、1.84）で表示確認

### パブリッシャー：rootProject名変更前

![画像3-1](https://github.com/solxyz-jsn/lineworks-sample-mq/assets/154206918/c2eca456-ff46-43c7-a75c-b242ad213895)

### パブリッシャー：rootProject名変更後

![画像3-2](https://github.com/solxyz-jsn/lineworks-sample-mq/assets/154206918/54f2881b-8a17-42a8-97fa-3f529b330542)

### コンシューマー：rootProject名変更前

![画像3-3](https://github.com/solxyz-jsn/lineworks-sample-mq/assets/154206918/2b409c72-6961-4834-8a0c-7b15e7ae93c5)

### コンシューマー：rootProject名変更後

![画像3-4](https://github.com/solxyz-jsn/lineworks-sample-mq/assets/154206918/6bfb09a3-b954-4f50-b02b-dc46f91601a3)
